### PR TITLE
Replace plugin constants with passed arguments

### DIFF
--- a/includes/Grrr/SimplyStaticDeploy/Admin.php
+++ b/includes/Grrr/SimplyStaticDeploy/Admin.php
@@ -9,14 +9,20 @@ class Admin {
     const JS_GLOBAL = 'GRRR_SIMPLY_STATIC_DEPLOY';
 
     private $basePath;
+    private $baseUrl;
+    private $version;
     private $config;
 
-    public function __construct(Config $config) {
+    public function __construct(
+        Config $config, string $basePath, string $baseUrl, string $version
+    ) {
         $this->config = $config;
+        $this->basePath = $basePath;
+        $this->baseUrl = $baseUrl;
+        $this->version = $version;
     }
 
-    public function register(string $basePath) {
-        $this->basePath = $basePath;
+    public function register() {
         add_action('admin_menu', [$this, 'admin_menu']);
         add_action('admin_enqueue_scripts', [$this, 'register_assets']);
         add_action('wp_before_admin_bar_render', [$this, 'admin_bar']);
@@ -43,8 +49,8 @@ class Admin {
     }
 
     public function register_assets() {
-        wp_register_style(static::SLUG, $this->get_asset_url('admin.css'), [], SIMPLY_STATIC_DEPLOY_VERSION);
-        wp_register_script(static::SLUG, $this->get_asset_url('admin.js'), ['jquery'], SIMPLY_STATIC_DEPLOY_VERSION);
+        wp_register_style(static::SLUG, $this->get_asset_url('admin.css'), [], $this->version);
+        wp_register_script(static::SLUG, $this->get_asset_url('admin.js'), ['jquery'], $this->version);
         wp_localize_script(static::SLUG, static::JS_GLOBAL, [
             'api' => [
                 'nonce' => wp_create_nonce('wp_rest'),
@@ -98,7 +104,7 @@ class Admin {
     }
 
     private function get_asset_url(string $filename): string {
-        return SIMPLY_STATIC_DEPLOY_URL . 'assets/' . $filename;
+        return rtrim($this->baseUrl, '/') . '/assets/' . $filename;
         $relative_assets_dir = substr($this->basePath, strlen(get_theme_file_path())) . '/assets';
         return get_theme_file_uri($relative_assets_dir . '/' . $filename);
     }

--- a/includes/Grrr/SimplyStaticDeploy/SimplyStaticDeploy.php
+++ b/includes/Grrr/SimplyStaticDeploy/SimplyStaticDeploy.php
@@ -7,9 +7,13 @@ class SimplyStaticDeploy {
     const CONFIG_CONST = 'SIMPLY_STATIC_DEPLOY_CONFIG';
 
     private $basePath;
+    private $baseUrl;
+    private $version;
 
-    public function __construct(string $basePath) {
+    public function __construct(string $basePath, string $baseUrl, string $version) {
         $this->basePath = $basePath;
+        $this->baseUrl = $baseUrl;
+        $this->version = $version;
     }
 
     public function init() {
@@ -29,7 +33,7 @@ class SimplyStaticDeploy {
         $config = new Config(constant(self::CONFIG_CONST));
 
         // Bootstrap components.
-        (new Admin($config))->register($this->basePath);
+        (new Admin($config, $this->basePath, $this->baseUrl, $this->version))->register();
         (new Api($config))->register();
         (new Scheduler($config))->register();
     }

--- a/simply-static-deploy.php
+++ b/simply-static-deploy.php
@@ -11,11 +11,15 @@ use Grrr\SimplyStaticDeploy\SimplyStaticDeploy;
 
 // Global constants.
 define('SIMPLY_STATIC_DEPLOY_VERSION', '0.1.0');
-define('SIMPLY_STATIC_DEPLOY_URL', plugin_dir_url(__FILE__));
 define('SIMPLY_STATIC_DEPLOY_PATH', plugin_dir_path(__FILE__));
+define('SIMPLY_STATIC_DEPLOY_URL', plugin_dir_url(__FILE__));
 
 // Require Composer autoloader.
 require_once SIMPLY_STATIC_DEPLOY_PATH . 'vendor/autoload.php';
 
 // Initialize the plugin.
-(new SimplyStaticDeploy(SIMPLY_STATIC_DEPLOY_PATH))->init();
+(new SimplyStaticDeploy(
+    SIMPLY_STATIC_DEPLOY_PATH,
+    SIMPLY_STATIC_DEPLOY_URL,
+    SIMPLY_STATIC_DEPLOY_VERSION
+))->init();


### PR DESCRIPTION
Since `SIMPLY_STATIC_DEPLOY_PATH` was being passed as an argument, I'd say it's all or nothing as discussed in #10, since those other constants are used in the `Admin` class too.

Somehow I still like the verbosity of the constants, mainly the version one. I could see it being forgotten quickly when bumping version, if it's only passed like so:

```php
(new SimplyStaticDeploy(plugin_dir_path(__FILE__), plugin_dir_url(__FILE__), '0.1.0'))->init();
```

In the case we're really going to ditch the constants altogether, named arguments or a more sophisticated solution probably work better:

```php
(new SimplyStaticDeploy([
    'basePath' => plugin_dir_path(__FILE__),
    'baseUrl' => plugin_dir_url(__FILE__)),
    'version' => '0.1.0',
]))->init();
```

Anyhow, let's not resolve to more bikeshedding... let's keep the path/version thing consistent. Thoughts?

PS: I moved the parameters for the `Admin` class to the constructor, felt more consistent.