### PR TITLE
Add support for DigitalOcean Spaces (and other providers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ### Deploy static sites easily to an AWS S3 bucket
 
 - Utilizes the excellent [Simply Static](https://wordpress.org/plugins/simply-static/) plugin for static site generation.
-- Adds deployment to a S3 bucket and optional CloudFront invalidation steps.
+- Adds deployment to S3-compatible storage (AWS S3, DigitalOcean Spaces, ...).
+- Adds optional CloudFront CDN invalidation step.
 - Steps can be triggered via a simple user interface or programmatically.
 - Customizable using hooks and actions.
 
@@ -44,6 +45,7 @@ define('SIMPLY_STATIC_DEPLOY_CONFIG', [
         'bucket'        => '...', # S3 bucket
         'bucket_acl'    => '...', # S3 bucket ACL (optional, defaults to `public-read`)
         'distribution'  => '...', # CloudFront distribution ID (optional, step is skipped when empty)
+        'endpoint'      => '...', # For usage with providers other than AWS (optional)
     ],
     'url' => '...', # Website url (used for displaying url after deploy is finished)
 ]);

--- a/includes/Aws/ClientProvider.php
+++ b/includes/Aws/ClientProvider.php
@@ -14,8 +14,11 @@ class ClientProvider {
         $credentials = $config->key && $config->secret
             ? (new CredentialsProvider($config->key, $config->secret))->getCredentials()
             : null;
+
+        // The SDK which creates clients.
         $this->sdk = new Sdk([
             'credentials' => $credentials,
+            'endpoint' => $config->endpoint ?: null,
             'region' => $config->region,
             'version' => 'latest',
             'http' => [

--- a/includes/Aws/CloudFront/Invalidation.php
+++ b/includes/Aws/CloudFront/Invalidation.php
@@ -2,9 +2,7 @@
 
 use WP_Error;
 use Exception;
-use Aws\Exception\AwsException;
 use Aws\CloudFront\CloudFrontClient;
-use Aws\CloudFront\Exception\CloudFrontException;
 
 class Invalidation {
 
@@ -34,18 +32,12 @@ class Invalidation {
                 ],
             ]);
             return true;
-        } catch (AwsException $error) {
-            $message = $error->getAwsRequestId() . PHP_EOL;
-            $message .= $error->getAwsErrorType() . PHP_EOL;
-            $message .= $error->getAwsErrorCode() . PHP_EOL;
-        } catch (CloudFrontException | Exception $error) {
-            $message = $error->getMessage();
+        } catch (Exception $error) {
+            $response = new WP_Error('cloudfront_invalidation_error', sprintf( __("Could not invalidate CloudFront distribution: %s", 'simply_static_deploy'), $error->getMessage()), [
+                'status' => 400,
+            ]);
+            do_action('simply_static_deploy_error', $response);
+            return $response;
         }
-
-        $error = new WP_Error('cloudfront_invalidation_error', sprintf( __("Could not invalidate CloudFront distribution: %s", 'simply_static_deploy'), $message), [
-            'status' => 400,
-        ]);
-        do_action('simply_static_deploy_error', $error);
-        return $error;
     }
 }


### PR DESCRIPTION
This adds support for DigitalOcean Spaces, and other providers. The former syncs perfectly, and was a breeze to set up and work with. But in the end it doesn't support `index.html` resolving, so isn't suited for website for now. They're working on it though:

> Customers have also been asking to host static websites from their Spaces as well. This feature is currently under development and will serve as a building block for a front-end-as-a-service solution that leverages some of the core building blocks of the object storage and CDN infrastructure that customers have come to love.

> We are looking to introduce static sites [later this year](https://ideas.digitalocean.com/ideas/DO-I-318). 

I've also simplified two AWS SDK specific try/catch blocks, because the `AwsException`-specific methods didn't return the right errors in this case, and the default `getMessage` always returns something meaningful. Maybe the type hints are a bit explicit now, but at least you know what you're getting.