### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,32 +2,19 @@
 
 This changelog only lists notable changes. Check individual releases (tags) and their commits to see unlisted changes.
 
-## v1.0.0 (2020-04-16)
+## v2.1.0 (2021-02-05)
 
-The plugin version was bumped from `v0.2.x` to `v1.x.x` to improve updating via Composer, due to restrictions in the [caret version range](https://getcomposer.org/doc/articles/versions.md#caret-version-range-). From the docs:
-
-> For pre-1.0 versions it also acts with safety in mind and treats `^0.3` as `>=0.3.0 <0.4.0`.
+-   Return of the `simply_static_deploy_modify_generated_files` action hook.
+-   Single static deploy will always deploy files from 'Additional Files' Simply Static setting.
+-   Only show single static deploy when jQuery is loaded.
+-   Add possibility to trigger CloudFront invalidation seperately
+-   Hide 'Generate' action from Simply Static plugin
 
 ## v2.0.0 (2020-10-19)
 
 From version v2.0.0 each deploy task will be done in the background.
 This means your browser window won't have to stay open while deploying. All the tasks will make separate requests, so the idle timeout limit of the server won't be reached.
 It is now also possible to only deploy a single post. Because of these changes we removed the ability to trigger each task individually.
-
-## v2.1.0 (2021-02-05)
-
-With the last major release we removed the `simply_static_deploy_modify_generated_files` action hook,
-but we never really wanted it to leave. But it got new complications because of the single deploy
-feature that got a high priority.
-
-Let's make it work!
-
-[X] Let generated files by modified before deploy
-[X] Single Deploy always with assets
-[X] Single Deploy button should be hidden until js is loaded
-[ ] Create the possibility to invalidate cloudfront anytime
-[ ] Show progress
-[ ] How can we make sure people use the right deploy button
 
 ### Updating from v1.\*
 
@@ -38,4 +25,8 @@ Removed actions and filters.
 
 `simply_static_deploy_php_execution_time` filter is removed, because it should not be needed anymore.
 
-`simply_static_deploy_modify_generated_files` action is removed, because this could have complications when deploying a single post
+## v1.0.0 (2020-04-16)
+
+The plugin version was bumped from `v0.2.x` to `v1.x.x` to improve updating via Composer, due to restrictions in the [caret version range](https://getcomposer.org/doc/articles/versions.md#caret-version-range-). From the docs:
+
+> For pre-1.0 versions it also acts with safety in mind and treats `^0.3` as `>=0.3.0 <0.4.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ Let's make it work!
 [X] Let generated files by modified before deploy
 [X] Single Deploy always with assets
 [X] Single Deploy button should be hidden until js is loaded
-[ ] Show progress
 [ ] Create the possibility to invalidate cloudfront anytime
+[ ] Show progress
 [ ] How can we make sure people use the right deploy button
 
 ### Updating from v1.\*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ From version v2.0.0 each deploy task will be done in the background.
 This means your browser window won't have to stay open while deploying. All the tasks will make separate requests, so the idle timeout limit of the server won't be reached.
 It is now also possible to only deploy a single post. Because of these changes we removed the ability to trigger each task individually.
 
+## v2.1.0 (2021-02-05)
+
+With the last major release we removed the `simply_static_deploy_modify_generated_files` action hook,
+but we never really wanted it to leave. But it got new complications because of the single deploy
+feature that got a high priority.
+
+Let's make it work!
+
+[X] Let generated files by modified before deploy
+[X] Single Deploy always with assets
+[ ] Single Deploy button should be hidden until js is loaded
+[ ] Create the possibility to invalidate cloudfront anytime
+[ ] How can we make sure people use the right deploy button
+
 ### Updating from v1.\*
 
 Since major architectual changed have been made, the scheduled event action hook is changed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Let's make it work!
 
 [X] Let generated files by modified before deploy
 [X] Single Deploy always with assets
-[ ] Single Deploy button should be hidden until js is loaded
+[X] Single Deploy button should be hidden until js is loaded
+[ ] Show progress
 [ ] Create the possibility to invalidate cloudfront anytime
 [ ] How can we make sure people use the right deploy button
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,18 @@
 -   Adds deployment to S3-compatible storage (AWS S3, DigitalOcean Spaces, ...).
 -   Adds optional CloudFront CDN invalidation step.
 -   Steps can be triggered via a simple user interface or programmatically.
+-   Ability to generate and deploy a single page
 -   Customizable using hooks and actions.
 
 Built with ❤️ by [GRRR](https://grrr.tech).
 
-<img width="557" alt="Screenshot of Simply Static Deploy plugin interface for WordPress" src="https://user-images.githubusercontent.com/1607628/71005872-b173a580-20e4-11ea-88e1-bef666f136cb.png">
+#### Generate and deploy user interface
+
+<img width="557" alt="Screenshot of Simply Static Deploy plugin interface for WordPress" src="https://user-images.githubusercontent.com/1799286/107524304-e9c22700-6bb5-11eb-8df1-1ded03b16df0.png">
+
+#### Single page/post deploy user interface
+
+<img width="557" alt="Screenshot of plugin interface for deploying a single page" src="https://user-images.githubusercontent.com/1799286/107524595-3d347500-6bb6-11eb-944b-25eb7b46cd03.png">
 
 ## Minimum requirements
 
@@ -127,6 +134,18 @@ Called from the plugin, and receives a `WP_Error` object explaining the error. Y
 ```php
 add_action('simply_static_deploy_error', function (\WP_Error $error) {
     # Handle the error.
+});
+```
+
+#### Modify generated files
+
+Called when Simply Static is done generating the static site. This allows you to modify the generated files before they're being deployed. The static site directory is passed as an argument.
+
+```php
+add_action('simply_static_deploy_modify_generated_files', function (
+    string $directory
+) {
+    # Modify generated files, like renaming or moving them.
 });
 ```
 

--- a/assets/admin.css
+++ b/assets/admin.css
@@ -65,3 +65,10 @@
 .deploy-tasks form > strong {
     min-width: 20px;
 }
+
+/**
+ * Hide 'Generate' button from Simply Static plugin
+ */
+#sistContainer .actions {
+    display: none !important;
+}

--- a/assets/admin.js
+++ b/assets/admin.js
@@ -13,6 +13,8 @@ const Deployer = ($) => {
   const $page = $(PAGE_SELECTOR);
 
   const $deployForm = $page.find(`form[data-type="ssd-deploy-form"]`);
+  const $invalidateForm = $page.find(`form[data-type="ssd-invalidate-form"]`);
+
   const $triggerButtons = $page.find(TRIGGER_BUTTONS_SELECTOR);
   const $errorContainer = $page.find(ERROR_CONTAINER_SELECTOR);
   const $errorMessage = $page.find(ERROR_MESSAGE_SELECTOR);
@@ -71,9 +73,25 @@ const Deployer = ($) => {
       });
   };
 
+  const handleInvalidateSubmit = (e) => {
+    e.preventDefault();
+    disableTriggerButtons();
+    hideError();
+
+    post($invalidateForm.prop("action"))
+      .then((response) => {
+        updateStatus("busy", response);
+      })
+      .catch((error) => {
+        showError(error);
+        enableTriggerButtons();
+      });
+  };
+
   return {
     init() {
       $deployForm.on("submit", handleDeploySubmit);
+      $invalidateForm.on("submit", handleInvalidateSubmit);
     },
   };
 };

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -91,13 +91,20 @@ class Admin
         wp_enqueue_script(static::SLUG);
         wp_enqueue_style(static::SLUG);
 
-        $form = (object) [
+        $deployForm = (object) [
             'action' => $this->get_endpoints()['simply_static_deploy'],
+            'method' => 'post',
+        ];
+        $invalidateForm = (object) [
+            'action' => $this->get_endpoints()['invalidate_cloudfront'],
             'method' => 'post',
         ];
 
         $renderer = new Renderer($this->basePath . 'views/admin-page.php', [
-            'form' => $form,
+            'forms' => [
+                'deploy' => $deployForm,
+                'invalidate' => $invalidateForm,
+            ],
             'in_progress' => !StaticDeployJob::is_job_done(),
             'last_end_time' => StaticDeployJob::last_end_time(),
         ]);

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -84,12 +84,14 @@ class Admin
             'tasks' => $this->get_tasks(),
             'website' => trim($this->config->url, '/') . '/',
         ]);
+
+        // Use style on every admin page so we can overwrite the css of Simply Static
+        wp_enqueue_style(static::SLUG);
     }
 
     public function render_admin()
     {
         wp_enqueue_script(static::SLUG);
-        wp_enqueue_style(static::SLUG);
 
         $deployForm = (object) [
             'action' => $this->get_endpoints()['simply_static_deploy'],

--- a/includes/Api.php
+++ b/includes/Api.php
@@ -5,6 +5,7 @@ namespace Grrr\SimplyStaticDeploy;
 use DateTime;
 use DateTimeZone;
 use Garp\Functional as f;
+use Grrr\SimplyStaticDeploy\Tasks\InvalidateTask;
 use Simply_Static\Util;
 use WP_Error;
 use WP_REST_Request;
@@ -19,6 +20,7 @@ class Api
         'generate_single' => 'generate_single',
         'simply_static_deploy' => 'simply_static_deploy',
         'poll_status' => 'poll_status',
+        'invalidate_cloudfront' => 'invalidate_cloudfront',
     ];
 
     private $config;
@@ -114,5 +116,14 @@ class Api
     {
         $status = StaticDeployJob::is_job_done() ? 'ready' : 'busy';
         return new WP_REST_Response($status, 200);
+    }
+
+    public function invalidate_cloudfront(WP_Rest_Request $request)
+    {
+        $invalidateTask = new InvalidateTask();
+        $response = $invalidateTask->perform();
+        return $response instanceof WP_Error
+            ? $response
+            : new WP_REST_Response('Cloudfront invalidation request sent', 200);
     }
 }

--- a/includes/Dependencies/SimplyStaticDependency.php
+++ b/includes/Dependencies/SimplyStaticDependency.php
@@ -1,12 +1,12 @@
 <?php namespace Grrr\SimplyStaticDeploy\Dependencies;
 
-use Simply_Static;
-
 class SimplyStaticDependency implements DependencyInterface
 {
     public function is_met(): bool
     {
-        return class_exists(Simply_Static\Plugin::class);
+        // https://waclawjacek.com/check-wordpress-plugin-dependencies/
+        $activePlugins = apply_filters('active_plugins', get_option('active_plugins'));
+        return in_array('simply-static/simply-static.php', $activePlugins);
     }
 
     public function register_notifications()

--- a/includes/RestRoutes.php
+++ b/includes/RestRoutes.php
@@ -12,6 +12,7 @@ class RestRoutes
         'generate_single' => 'generate_single',
         'simply_static_deploy' => 'simply_static_deploy',
         'poll_status' => 'poll_status',
+        'invalidate_cloudfront' => 'invalidate_cloudfront',
     ];
 
     public static function get(string $name): string

--- a/includes/SimplyStaticDeploy.php
+++ b/includes/SimplyStaticDeploy.php
@@ -20,7 +20,7 @@ class SimplyStaticDeploy
 
     public function init()
     {
-        add_action('plugins_loaded', [$this, 'plugins_loaded']);
+        add_action('init', [$this, 'plugins_loaded']);
     }
 
     public function plugins_loaded()

--- a/includes/StaticDeployJob.php
+++ b/includes/StaticDeployJob.php
@@ -4,6 +4,7 @@ namespace Grrr\SimplyStaticDeploy;
 
 use Garp\Functional as f;
 use Grrr\SimplyStaticDeploy\Tasks\InvalidateTask;
+use Grrr\SimplyStaticDeploy\Tasks\ModifyGeneratedFilesTask;
 use Grrr\SimplyStaticDeploy\Tasks\RestoreInitialOptionsTask;
 use Grrr\SimplyStaticDeploy\Tasks\SetupSingleTask;
 use Grrr\SimplyStaticDeploy\Tasks\StoreInitialOptionsTask;
@@ -35,6 +36,7 @@ class StaticDeployJob extends \WP_Background_Process
         'fetch_urls' => Fetch_Urls_Task::class,
         'transfer_files_locally' => Transfer_Files_Locally_Task::class,
         'wrapup' => Wrapup_Task::class,
+        'modify_generated_files' => ModifyGeneratedFilesTask::class,
         'restore_initial_options' => RestoreInitialOptionsTask::class,
         'sync' => SyncTask::class,
         'invalidate' => InvalidateTask::class,
@@ -374,6 +376,7 @@ class StaticDeployJob extends \WP_Background_Process
             'fetch_urls',
             'transfer_files_locally',
             'wrapup',
+            'modify_generated_files',
             'restore_initial_options',
             'sync',
             'invalidate',

--- a/includes/Tasks/ModifyGeneratedFilesTask.php
+++ b/includes/Tasks/ModifyGeneratedFilesTask.php
@@ -1,0 +1,20 @@
+<?php namespace Grrr\SimplyStaticDeploy\Tasks;
+
+use Simply_Static\Options;
+use Simply_Static\Task;
+use Simply_Static\Util;
+
+class ModifyGeneratedFilesTask extends Task {
+
+    const MODIFY_ACTION = 'simply_static_deploy_modify_generated_files';
+
+    public function perform() {
+        Util::debug_log('Modify generated files');
+        $this->save_status_message(
+            "Modify generated files"
+        );
+        $localDir = Options::instance()->get('local_dir') ?: '';
+        do_action(static::MODIFY_ACTION, $localDir);
+        return true;
+    }
+}

--- a/includes/Tasks/SetupSingleTask.php
+++ b/includes/Tasks/SetupSingleTask.php
@@ -4,6 +4,7 @@ namespace Grrr\SimplyStaticDeploy\Tasks;
 
 use Simply_Static\Page;
 use Simply_Static\Plugin;
+use Simply_Static\Setup_Task;
 use Simply_Static\Task;
 use Simply_Static\Util;
 
@@ -45,9 +46,11 @@ class SetupSingleTask extends Task
         $static_page->found_on_id = 0;
         $static_page->save();
 
+        Setup_Task::add_additional_files_to_db( $this->options->get( 'additional_files' ) );
+
         // We should add the URL to the urls_to_exclude option with
         // do_not_follow = 1
-        // That way we ONLY generate that single URL.
+        // That way we ONLY generate/save that single URL, but not following it
         // @see Simply_Static\Fetch_Urls_Task::find_excludable()
         $excludedUrls = array_merge($this->options->get('urls_to_exclude'), [
             [
@@ -57,7 +60,6 @@ class SetupSingleTask extends Task
             ],
         ]);
         $this->options->set('urls_to_exclude', $excludedUrls)->save();
-
         return true;
     }
 }

--- a/simply-static-deploy.php
+++ b/simply-static-deploy.php
@@ -10,7 +10,7 @@
 use Grrr\SimplyStaticDeploy\SimplyStaticDeploy;
 
 // Global constants.
-define('SIMPLY_STATIC_DEPLOY_VERSION', '2.0.6');
+define('SIMPLY_STATIC_DEPLOY_VERSION', '2.1.0');
 define('SIMPLY_STATIC_DEPLOY_PATH', plugin_dir_path(__FILE__));
 define('SIMPLY_STATIC_DEPLOY_URL', plugin_dir_url(__FILE__));
 

--- a/views/admin-page.php
+++ b/views/admin-page.php
@@ -8,23 +8,40 @@
             <h1><?= get_admin_page_title() ?></h1>
             <p>Generate a static version of the website, sync it to the static hosting environment, and invalidate the cache.</p>
             <div class="wp-clearfix" style="margin-bottom: 15px;">
-                <form 
-                    class="alignleft" 
+                <form
+                    class="alignleft"
                     data-type="ssd-deploy-form"
-                    action="<?= $this->form->action ?>" 
-                    method="<?= $this->form->method ?>" 
+                    action="<?= $this->forms['deploy']->action ?>"
+                    method="<?= $this->forms['deploy']->method ?>"
                     style="margin-right: 10px;"
                     >
                     <?= wp_nonce_field('wp_rest') ?>
-                    <button 
-                        class="button button-primary button-large js-trigger-button" 
+                    <button
+                        class="button button-primary button-large js-trigger-button"
                         type="submit"
                         <?= $this->in_progress ? 'disabled' : '' ?>
                         >
                         Generate &amp; deploy
                     </button>
                 </form>
-            </div>
+                <div class="wp-clearfix" style="margin-bottom: 15px;">
+                    <form
+                        class="alignleft"
+                        data-type="ssd-invalidate-form"
+                        action="<?= $this->forms['invalidate']->action ?>"
+                        method="<?= $this->forms['invalidate']->method ?>"
+                        style="margin-right: 10px;"
+                        >
+                        <?= wp_nonce_field('wp_rest') ?>
+                        <button
+                            class="button button-secondary button-large js-trigger-button"
+                            type="submit"
+                            <?= $this->in_progress ? 'disabled' : '' ?>
+                            >
+                            Invalidate CloudFront
+                        </button>
+                    </form>
+                </div>
             <hr />
             <span class="js-status"><?= $this->in_progress
                 ? 'Deployment in progress...'

--- a/views/post-submit-actions.php
+++ b/views/post-submit-actions.php
@@ -1,6 +1,9 @@
 <style>
 .ssd-publishbox {
 }
+.ssd-publishbox[aria-hidden="true"] {
+    visibility: hidden;
+}
 .ssd-publishbox__status[data-status="ready"] {
     color: gray;
 }
@@ -13,23 +16,24 @@
     color: red;
 }
 </style>
-<!-- 
-    Note: since this partial will be injected in to the edit post action, 
-    we should tell tell the button it should belong to another form 
+<!--
+    Note: since this partial will be injected in to the edit post action,
+    we should tell tell the button it should belong to another form
 -->
-<div 
+<div
     id="ssd-single-deploy-submit-container"
-    class="misc-pub-section sdd-publishbox" 
+    class="misc-pub-section ssd-publishbox"
+    aria-hidden="true"
     data-poll-status-endpoint="<?= $this->poll_status_endpoint ?>"
     >
-    <button 
-        type="submit" 
-        form="<?= $this->form_id ?>" 
+    <button
+        type="submit"
+        form="<?= $this->form_id ?>"
         <?= $this->status === 'busy' ? 'disabled' : '' ?>
         >
         Deploy
     </button>
-    <span 
+    <span
         class="ssd-publishbox__status"
         data-status="<?= $this->status ?>"
         >
@@ -40,10 +44,11 @@
 <script>
 const StaticDeploySingle = ($) => {
     const $container = $('#ssd-single-deploy-submit-container');
+    $container.attr('aria-hidden', false);
     const $button = $container.find('button[type=submit]');
     const $form = $($button.prop('form'));
     const $statusElement = $container.find('.ssd-publishbox__status');
-    
+
     const POLL_STATUS_ENDPOINT = $container.data('poll-status-endpoint');
 
     const formGetValue = (key) => {
@@ -101,7 +106,7 @@ const StaticDeploySingle = ($) => {
         window.setInterval(pollStatus, 2 * 1000);
         disableSubmitButton();
         post(
-            $form.prop('action'), 
+            $form.prop('action'),
             {
               post_id: formGetValue('post_id'),
             }
@@ -118,7 +123,7 @@ const StaticDeploySingle = ($) => {
     return {
         init: () => {
             $form.on('submit', handleDeploySubmit);
-            
+
         }
     };
 }

--- a/views/post-submit-actions.php
+++ b/views/post-submit-actions.php
@@ -50,6 +50,7 @@ const StaticDeploySingle = ($) => {
     const $statusElement = $container.find('.ssd-publishbox__status');
 
     const POLL_STATUS_ENDPOINT = $container.data('poll-status-endpoint');
+    let pollStatusInterval;
 
     const formGetValue = (key) => {
         return $form.serializeArray()
@@ -97,14 +98,15 @@ const StaticDeploySingle = ($) => {
                 }
             })
             .catch((error) => {
+                window.clearInterval(pollStatusInterval);
                 updateStatus('error', error);
             });
     }
 
     const handleDeploySubmit = (e) => {
         e.preventDefault();
-        window.setInterval(pollStatus, 2 * 1000);
         disableSubmitButton();
+        updateStatus('busy', 'Deployment in progress...');
         post(
             $form.prop('action'),
             {
@@ -112,9 +114,10 @@ const StaticDeploySingle = ($) => {
             }
             )
             .then( (response) => {
-                updateStatus('busy', 'Deployment in progress...');
+                pollStatusInterval = window.setInterval(pollStatus, 2 * 1000);
             })
             .catch((error) => {
+                window.clearInterval(pollStatusInterval);
                 updateStatus('error', error);
                 enableSubmitButton();
             })


### PR DESCRIPTION
-   Return of the `simply_static_deploy_modify_generated_files` action hook.
-   Single static deploy will always deploy files from 'Additional Files' Simply Static setting.
-   Only show single static deploy when jQuery is loaded.
-   Add possibility to trigger CloudFront invalidation seperately
-   Hide 'Generate' action from Simply Static plugin
-   Make it work with updated Simply Static plugin