### PR TITLE
Remove Cloudfront invalidation for deleted objects

### DIFF
--- a/includes/SimplyStaticDeploy.php
+++ b/includes/SimplyStaticDeploy.php
@@ -147,20 +147,6 @@ class SimplyStaticDeploy
             'Key' => $s3Key,
         ]);
 
-        // Invalidate cloudfront.
-        if ($config->aws->distribution) {
-            $invalidationPaths = [
-                rtrim($relativePermalink, '/'),
-                $relativePermalink,
-                $relativePermalink . 'index.html',
-            ];
-            $invalidation = new Invalidation(
-                $clientProvider->getCloudFrontClient(),
-                $config->aws->distribution
-            );
-
-            $invalidation->invalidate($invalidationPaths);
-        }
     }
 
     /**


### PR DESCRIPTION
Since these objects don't need invalidation, and can cause warnings